### PR TITLE
Switch to runtime api to capture exceptions correctly

### DIFF
--- a/chrome-extension/manifest.json
+++ b/chrome-extension/manifest.json
@@ -1,6 +1,6 @@
 {
     "name": "BrowserTools MCP",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "description": "MCP tool for AI code editors to capture data from a browser such as console logs, network requests, screenshots and more",
     "manifest_version": 3,
     "devtools_page": "devtools.html",


### PR DESCRIPTION
The previous way of capturing logs and exceptions was not reliable if you had other error handlers like Sentry and Apollo clients for network in the page's context.
The console domain is also deprecated in the DevTools protocol as mentioned in [https://chromedevtools.github.io/devtools-protocol/tot/Console/](https://chromedevtools.github.io/devtools-protocol/tot/Console/).