### PR TITLE
feat: Add configurable port support

### DIFF
--- a/browser-tools-mcp/README.md
+++ b/browser-tools-mcp/README.md
@@ -28,7 +28,11 @@ npm install -g @agentdeskai/browser-tools-mcp
 1. First, make sure the Browser Tools Server is running:
 
 ```bash
+# Default port (3025)
 npx @agentdeskai/browser-tools-server
+
+# Or with custom port
+MCP_PORT=3030 npx @agentdeskai/browser-tools-server
 ```
 
 2. Then start the MCP server:
@@ -37,7 +41,12 @@ npx @agentdeskai/browser-tools-server
 npx @agentdeskai/browser-tools-mcp
 ```
 
-3. The MCP server will connect to the Browser Tools Server and provide the following capabilities:
+3. Configure the Chrome Extension:
+   - Open Chrome DevTools (F12 or Cmd+Option+I)
+   - Select the "BrowserToolsMCP" panel
+   - In the Connection Settings section, set the Server Port if needed (default is 3025)
+
+4. The MCP server will connect to the Browser Tools Server and provide the following capabilities:
 
 - Console log retrieval
 - Network request monitoring

--- a/browser-tools-server/README.md
+++ b/browser-tools-server/README.md
@@ -10,6 +10,7 @@ A powerful browser tools server for capturing and managing browser events, logs,
 - Element selection tracking
 - WebSocket real-time communication
 - Configurable log limits and settings
+- Configurable server port via environment variable
 
 ## Installation
 
@@ -28,10 +29,14 @@ npm install -g @agentdeskai/browser-tools-server
 1. Start the server:
 
 ```bash
+# Default port (3025)
 npx @agentdeskai/browser-tools-server
+
+# Custom port
+MCP_PORT=3030 npx @agentdeskai/browser-tools-server
 ```
 
-2. The server will start on port 3025 by default
+2. The server will start on port 3025 by default. You can configure the port using the `MCP_PORT` environment variable.
 
 3. Install and enable the Browser Tools Chrome Extension
 

--- a/browser-tools-server/README.md
+++ b/browser-tools-server/README.md
@@ -38,7 +38,12 @@ MCP_PORT=3030 npx @agentdeskai/browser-tools-server
 
 2. The server will start on port 3025 by default. You can configure the port using the `MCP_PORT` environment variable.
 
+   **Important:** If you change the server port, you must also update the port in the Browser Tools Chrome Extension settings to match. Both the server and extension must use the same port to communicate.
+
 3. Install and enable the Browser Tools Chrome Extension
+   - Open Chrome DevTools (F12 or Cmd+Option+I)
+   - Select the "BrowserToolsMCP" panel
+   - In the Connection Settings section, set the Server Port if needed (default is 3025)
 
 4. The server exposes the following endpoints:
 

--- a/browser-tools-server/browser-connector.ts
+++ b/browser-tools-server/browser-connector.ts
@@ -50,7 +50,8 @@ interface ScreenshotCallback {
 const screenshotCallbacks = new Map<string, ScreenshotCallback>();
 
 const app = express();
-const PORT = 3025;
+// Allow port configuration via environment variable
+const PORT = process.env.MCP_PORT ? parseInt(process.env.MCP_PORT, 10) : 3025;
 
 app.use(cors());
 // Increase JSON body parser limit to 50MB to handle large screenshots

--- a/browser-tools-server/package.json
+++ b/browser-tools-server/package.json
@@ -22,6 +22,14 @@
   ],
   "author": "AgentDesk AI",
   "license": "MIT",
+  "config": {
+    "port": "3025"
+  },
+  "env": {
+    "MCP_PORT": {
+      "description": "Port number for the browser tools server (default: 3025)"
+    }
+  },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.4.1",
     "body-parser": "^1.20.3",

--- a/chrome-extension/manifest.json
+++ b/chrome-extension/manifest.json
@@ -11,7 +11,8 @@
       "tabs"
     ],
     "host_permissions": [
-      "<all_urls>"
+      "http://127.0.0.1:*/*",
+      "ws://localhost:*/*"
     ]
   }
   

--- a/chrome-extension/panel.html
+++ b/chrome-extension/panel.html
@@ -126,6 +126,19 @@
     </div>
 
     <div class="settings-section">
+        <h3>Connection Settings</h3>
+        <div class="form-group">
+            <label for="server-port">Server Port</label>
+            <div class="port-input-group">
+                <input type="number" id="server-port" min="1" max="65535" placeholder="3025">
+                <button id="connect-server" class="action-button">Connect</button>
+            </div>
+            <div id="connection-status"></div>
+            <small>Default is 3025. If using a custom port via the MCP_PORT environment variable, set it to match here.</small>
+        </div>
+    </div>
+
+    <div class="settings-section">
         <h3>Screenshot Settings</h3>
         <div class="form-group">
             <label for="screenshot-path">Provide a directory to save screenshots to (by default screenshots will be saved to your downloads folder if no path is provided)</label>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,6 @@
+{
+  "name": "browser-tools-mcp",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {}
+}


### PR DESCRIPTION
This PR adds support for configurable ports in the browser tools server, so that users with conflicting applications running on the default port don't encounter conflicts.

Key changes:
- Made the server port configurable through environment variables
- Updated documentation to reflect port configuration options
- Ensures backward compatibility with default port settings
- Improves development flexibility by allowing custom port assignments