### PR TITLE
Include screenshot in MCP response when taking sceenshot

### DIFF
--- a/browser-tools-mcp/mcp-server.ts
+++ b/browser-tools-mcp/mcp-server.ts
@@ -1,9 +1,10 @@
 #!/usr/bin/env node
 
-import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { McpServer, ToolCallback } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import path from "path";
 import fs from "fs";
+import { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 
 // Create the MCP server
 const server = new McpServer({
@@ -251,7 +252,7 @@ server.tool("getNetworkLogs", "Check ALL our network logs", async () => {
 server.tool(
   "takeScreenshot",
   "Take a screenshot of the current browser tab",
-  async () => {
+  async (): Promise<CallToolResult> => {
     return await withServerConnection(async () => {
       try {
         const response = await fetch(
@@ -262,13 +263,17 @@ server.tool(
         );
 
         const result = await response.json();
-
+        console.log(result)
         if (response.ok) {
+          // base 64 encoded representation of screenshot
+          const screenshotBase64 = fs.readFileSync(result.path, 'base64');
+
           return {
             content: [
               {
-                type: "text",
-                text: "Successfully saved screenshot",
+                type: "image",
+                data: screenshotBase64,
+                mimeType: "image/png",
               },
             ],
           };

--- a/browser-tools-mcp/mcp-server.ts
+++ b/browser-tools-mcp/mcp-server.ts
@@ -252,7 +252,7 @@ server.tool("getNetworkLogs", "Check ALL our network logs", async () => {
 server.tool(
   "takeScreenshot",
   "Take a screenshot of the current browser tab",
-  async (): Promise<CallToolResult> => {
+  async () => {
     return await withServerConnection(async () => {
       try {
         const response = await fetch(
@@ -263,19 +263,20 @@ server.tool(
         );
 
         const result = await response.json();
-        console.log(result)
         if (response.ok) {
-          // base 64 encoded representation of screenshot
-          const screenshotBase64 = fs.readFileSync(result.path, 'base64');
-
           return {
             content: [
               {
+                type: "text",
+                text: "Successfully saved screenshot",
+              },
+              {
                 type: "image",
-                data: screenshotBase64,
+                // base 64 encoded representation of screenshot
+                data: fs.readFileSync(result.path, 'base64'),
                 mimeType: "image/png",
               },
-            ],
+            ]
           };
         } else {
           return {

--- a/browser-tools-mcp/mcp-server.ts
+++ b/browser-tools-mcp/mcp-server.ts
@@ -1,10 +1,9 @@
 #!/usr/bin/env node
 
-import { McpServer, ToolCallback } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import path from "path";
 import fs from "fs";
-import { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 
 // Create the MCP server
 const server = new McpServer({

--- a/browser-tools-mcp/mcp-server.ts
+++ b/browser-tools-mcp/mcp-server.ts
@@ -272,7 +272,7 @@ server.tool(
               {
                 type: "image",
                 // base 64 encoded representation of screenshot
-                data: fs.readFileSync(result.path, 'base64'),
+                data: await fs.promises.readFile(result.path, 'base64'),
                 mimeType: "image/png",
               },
             ]


### PR DESCRIPTION
This PR includes the taken screenshot in base64 format besides the existing text response. Now the MCP caller can read the image themselves (for example Cursor).

I have included a example below where it can describe the taken screenshot in Cursor:
Love this MCP server and let me know if I can make any improvements to my PR!

![afbeelding](https://github.com/user-attachments/assets/2450911a-6a6b-4212-a56f-250669e55360)
