### PR TITLE
Add browser tools MCP package metadata

### DIFF
--- a/browser-tools-mcp/package.json
+++ b/browser-tools-mcp/package.json
@@ -1,6 +1,15 @@
 {
   "name": "@agentdeskai/browser-tools-mcp",
   "version": "1.2.0",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/AgentDeskAI/browser-tools-mcp.git",
+    "directory": "browser-tools-mcp"
+  },
+  "bugs": {
+    "url": "https://github.com/AgentDeskAI/browser-tools-mcp/issues"
+  },
+  "homepage": "https://github.com/AgentDeskAI/browser-tools-mcp/tree/main/browser-tools-mcp#readme",
   "description": "MCP (Model Context Protocol) server for browser tools integration",
   "main": "dist/mcp-server.js",
   "bin": {


### PR DESCRIPTION
## Summary
- add npm package source metadata for repository, issue tracker, and package README
- include the repository directory because this package lives under browser-tools-mcp/
- keep the change scoped to package.json metadata only

## Validation
- checked published npm metadata for @agentdeskai/browser-tools-mcp@1.2.1
- parsed browser-tools-mcp/package.json successfully after the edit
- verified repository, bugs, and homepage values point to this public repo/package directory